### PR TITLE
add `which=` keyword to decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ puttext(0., 'hi')
 puttext(0., 1., 'hi')
 ```
 
+The `@leftdefault` decorator accepts an optional `which=` keyword argument to
+specify the exact sequence of default arguments to be moved to the left:
+
+```py
+@leftdefault(which='greeting, prefix, forename')
+def greet(surname, forename='Alice', greeting='Welcome', prefix='Mrs', suffix='Esq', /):
+    print(greeting, prefix, forename, surname, suffix)
+
+# these are now equivalent
+greet('Smith')
+greet('Alice', 'Smith')
+greet('Welcome', 'Alice', 'Smith')
+greet('Welcome', 'Mrs', 'Alice', 'Smith')
+greet('Welcome', 'Mrs', 'Alice', 'Smith', 'Esq')
+```
+
+The order in which default arguments are filled is the order in which they
+are defined in the original function.
+
 The `@leftdefault` decorator can take an optional `skip=N` keyword argument to
 indicate that `N` initial positional-only arguments should be skipped.  This is
 necessary for methods with `self`:
@@ -84,5 +103,11 @@ myrange(start=0, stop, /, step=1)
 Help on function puttext:
 
 puttext(x=None, y=None, text, /, *args, **kwargs)
+
+>>> help(greet)
+
+Help on function greet:
+
+greet(greeting='Welcome', prefix='Mrs', forename='Alice', surname, suffix='Esq', /)
 
 ```

--- a/leftdefault.py
+++ b/leftdefault.py
@@ -8,7 +8,8 @@ __all__ = ['leftdefault']
 from functools import wraps, cached_property, partial
 from inspect import Parameter, Signature as _Signature
 from types import MappingProxyType
-from typing import Any, Callable, Tuple, TypeVar, overload
+from typing import Any, Callable, List, Sequence, Tuple, TypeVar, Union
+from typing import overload
 
 F = TypeVar('F', bound=Callable[..., Any])
 
@@ -22,15 +23,22 @@ class Signature(_Signature):
     '''
 
     left_default_skip: int = 0
+    left_default_which: Union[Sequence[str], None] = None
 
     @cached_property
-    def left_default_splits(self) -> Tuple[int, int, int]:
+    def left_default_splits(self) -> Tuple[int, int, int,
+                                           Union[List[Tuple[int, ...]], None]]:
         '''Take the list of positional-only arguments and return indices
         i, j, k such that
             - args[:i] are skipped over,
             - args[i:j] are required, and
             - args[j:k] are optional.
         '''
+
+        which = self.left_default_which
+        if which is not None:
+            base_order = []
+
         i = k = self.left_default_skip
         j = -1
         for k, par in enumerate(super().parameters.values()):
@@ -38,52 +46,97 @@ class Signature(_Signature):
                 continue
             if par.kind != par.POSITIONAL_ONLY:
                 break
-            if par.default != par.empty and j == -1:
-                j = k
+            if par.default != par.empty:
+                if j == -1:
+                    j = k
+                if which is not None:
+                    try:
+                        base_order.append(which.index(par.name))
+                    except ValueError:
+                        break
         if j == -1:
             j = k
         if i > k:
             i = k
-        return i, j, k
+
+        # precompute the sort order for all optional argument counts
+        if which is not None:
+            inv = sorted(range(len(base_order)), key=base_order.__getitem__)
+            order = []
+            for n in range(len(inv)+1):
+                n_inv = [m for m in inv if m < n]
+                n_order = sorted(range(n), key=n_inv.__getitem__)
+                order.append(tuple(n_order))
+            assert order[-1] == tuple(base_order)
+        else:
+            order = None
+
+        return i, j, k, order
 
     @cached_property
     def parameters(self) -> MappingProxyType[str, Parameter]:
         '''Reordered parameters list with left-defaults.'''
         pars = super().parameters
         names = list(pars.keys())
-        i, j, k = self.left_default_splits
+        i, j, k, order = self.left_default_splits
+        optnames = names[j:k]
+        if order is not None:
+            optnames = [name for _, name in sorted(zip(order[-1], optnames))]
         return MappingProxyType({name: pars[name]
-                                 for name in (*names[:i], *names[j:k],
+                                 for name in (*names[:i], *optnames,
                                               *names[i:j], *names[k:])})
 
 
 @overload
-def leftdefault(func: F, /, *, skip: int = 0) -> F:
+def leftdefault(func: F, /, *,
+                skip: int = 0,
+                which: Union[str, Sequence[str], None] = None,
+                ) -> F:
     ...
 
 
 @overload
-def leftdefault(func: None, /, *, skip: int = 0) -> Callable[[F], F]:
+def leftdefault(func: None, /, *,
+                skip: int = 0,
+                which: Union[str, Sequence[str], None] = None,
+                ) -> Callable[[F], F]:
     ...
 
 
-def leftdefault(func: Any, /, *, skip: Any = 0) -> Any:
+def leftdefault(func: Any = None, /, *,
+                skip: int = 0,
+                which: Union[str, Sequence[str], None] = None,
+                ) -> Any:
     '''Move positional-only default arguments to the left.'''
     if func is None:
-        return partial(leftdefault, skip=skip)
+        return partial(leftdefault, skip=skip, which=which)
 
     if not callable(func):
         raise TypeError('func must be callable')
 
+    if isinstance(which, str):
+        which = tuple(map(str.strip, which.split(',')))
+
     sig = Signature.from_callable(func)
     sig.left_default_skip = skip
-    i, j, k = sig.left_default_splits
+    sig.left_default_which = which
+    i, j, k, order = sig.left_default_splits
     n = j - i
 
-    @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        skip, pos, rest = args[:i], args[i:k], args[k:]
-        return func(*skip, *pos[-n:], *pos[:-n], *rest, **kwargs)
+    if order is None:
+        @wraps(func)
+        def wrapper(*args: object, **kwargs: object) -> Any:
+            skip, pos, rest = args[:i], args[i:k], args[k:]
+            return func(*skip, *pos[-n:], *pos[:-n], *rest, **kwargs)
+    else:
+        x: List[Tuple[int, ...]] = order
+
+        @wraps(func)
+        def wrapper(*args: object, **kwargs: object) -> Any:
+            skip, pos, rest = args[:i], args[i:k], args[k:]
+            opt = pos[:-n]
+            return func(*skip, *pos[-n:], *(opt[o] for o in x[len(opt)]),
+                        *rest, **kwargs)
 
     wrapper.__signature__ = sig  # type: ignore[attr-defined]
 


### PR DESCRIPTION
This PR adds the `which=` keyword to the decorator to allow explicit selection and ordering of left-default arguments.

Closes #2.